### PR TITLE
Add Zilliz Cloud Launch Week

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 > You? [Create an issue](https://github.com/supabase-community/launchweek.dev/issues) or open a [Pull Request (PR)](https://github.com/supabase-community/launchweek.dev/pulls) to add your upcoming launch week here. Enjoy the fun!
 
+- 2024 / 01 / 30-08: Zilliz Cloud Launch Week. [Teaser ↗︎](https://twitter.com/zilliz_universe/status/1750552090458693958)
 - 2024 / 01 / 23-29: Wasp Launch Week #5.
 - 2024 / 01 / 22-25: Inngest Launch Week. [Teaser ↗︎](https://twitter.com/inngest/status/1746942045820719172) [Go to launch page ↗︎](https://www.inngest.com/launch-week)
 
@@ -42,7 +43,7 @@ For best practices, read this:
 
 > Total count: 6
 > 
-- 2024 / 01 / 30-8: Zilliz Cloud Launch Week. [Teaser ↗︎](https://twitter.com/zilliz_universe/status/1750552090458693958)
+- 2024 / 01 / 30-08: Zilliz Cloud Launch Week. [Teaser ↗︎](https://twitter.com/zilliz_universe/status/1750552090458693958)
 - 2024 / 01 / 23-29: Wasp Launch Week #5.
 - 2024 / 01 / 22-25: Inngest Launch Week. [Teaser ↗︎](https://twitter.com/inngest/status/1746942045820719172) [Go to launch page ↗︎](https://www.inngest.com/launch-week)
 - 2024 / 01 / 15-19: Resend Launch Week #2. [Teaser ↗︎](https://x.com/resend/status/1744374127887040933?s=20) [Read the recap ↗︎](https://x.com/zenorocha/status/1749461869948186975?s=20) [Go to launch page ↗︎](https://resend.com/forward)

--- a/README.md
+++ b/README.md
@@ -40,8 +40,9 @@ For best practices, read this:
 
 ### 2024
 
-> Total count: 5
-
+> Total count: 6
+> 
+- 2024 / 01 / 30-8: Zilliz Cloud Launch Week. [Teaser ↗︎](https://twitter.com/zilliz_universe/status/1750552090458693958)
 - 2024 / 01 / 23-29: Wasp Launch Week #5.
 - 2024 / 01 / 22-25: Inngest Launch Week. [Teaser ↗︎](https://twitter.com/inngest/status/1746942045820719172) [Go to launch page ↗︎](https://www.inngest.com/launch-week)
 - 2024 / 01 / 15-19: Resend Launch Week #2. [Teaser ↗︎](https://x.com/resend/status/1744374127887040933?s=20) [Read the recap ↗︎](https://x.com/zenorocha/status/1749461869948186975?s=20) [Go to launch page ↗︎](https://resend.com/forward)


### PR DESCRIPTION
Hope I did this right (if not, I am SO sorry), I added our launch info directly into the Readme.

Added the Zilliz Cloud launch week:
- 2024 / 01 / 30-8: Zilliz Cloud Launch Week. [Teaser ↗︎](https://twitter.com/zilliz_universe/status/1750552090458693958)