### PR TITLE
Update with Koyeb's upcoming launch week

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 > You? [Create an issue](https://github.com/supabase-community/launchweek.dev/issues) or open a [Pull Request (PR)](https://github.com/supabase-community/launchweek.dev/pulls) to add your upcoming launch week here. Enjoy the fun!
 
-- 
+- 2024 / 06 / 17-21: Koyeb Launch Week. [Teaser ↗︎](https://x.com/yann_eu/status/1796555252663243030)
 
 ## Intro
 

--- a/README.md
+++ b/README.md
@@ -39,8 +39,9 @@ For best practices, read this:
 
 ### 2024
 
-> Total count: 28
+> Total count: 29
 
+- 2024 / 06 / 17-21: Koyeb Launch Week. [Teaser ↗︎](https://x.com/yann_eu/status/1796555252663243030)
 - 2024 / 05 / 20-24: OpenSauced Launch Week. [Teaser ↗︎](https://twitter.com/saucedopen/status/1790117385199919469)
 - 2024 / 05 / 06-10: AWS Amplify Launch Week #2. [Teaser ↗︎](https://x.com/AWSAmplify/status/1783875739290419552)
 - 2024 / 05 / 06-10: Encore Launch Week. [Teaser ↗︎](https://twitter.com/encoredotdev/status/1782323908957409649)


### PR DESCRIPTION
Update upcoming list with Koyeb's launch week

## What kind of change does this PR introduce?

Adds Koyeb launch week to the list of 2024 launch weeks

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
