### PR TITLE
add Langfuse launch week #2 - Nov, 17 - Nov, 22 2024

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 > You? [Create an issue](https://github.com/supabase-community/launchweek.dev/issues) or open a [Pull Request (PR)](https://github.com/supabase-community/launchweek.dev/pulls) to add your upcoming launch week here. Enjoy the fun!
 
+- 2024 / 11 / 17-22: Langfuse Launch Week #2. [Teaser ↗︎](https://x.com/MarcKlingen/status/1857091135983780039) [Go to launch page ↗︎](https://langfuse.com/launch)
 - 2024 / 11 / 18-22: WorkOS Launch Week #2. [Teaser ↗︎](https://x.com/WorkOS/status/1856046332407906341) [Go to launch page ↗︎](https://workos.com/launch-week)
 - 2024 / 11 / 25-29: Trigger.dev Launch Week. [Teaser ↗︎](https://x.com/triggerdotdev/status/1856375219092332752) [Go to launch page ↗︎](https://trigger.dev/launchweek/0)
 - 2024 / 12 / 02-06: Supabase Launch Week #13.
@@ -41,11 +42,12 @@ For best practices, read this:
 
 ### 2024
 
-> Total count: 57
+> Total count: 58
 
 - 2024 / 12 / 02-06: Supabase Launch Week #13.
 - 2024 / 11 / 25-29: Trigger.dev Launch Week. [Teaser ↗︎](https://x.com/triggerdotdev/status/1856375219092332752) [Go to launch page ↗︎](https://trigger.dev/launchweek/0) 
 - 2024 / 11 / 18-22: WorkOS Launch Week #2. [Teaser ↗︎](https://x.com/WorkOS/status/1856046332407906341) [Go to launch page ↗︎](https://workos.com/launch-week)
+- 2024 / 11 / 17-22: Langfuse Launch Week #2. [Teaser ↗︎](https://x.com/MarcKlingen/status/1857091135983780039) [Go to launch page ↗︎](https://langfuse.com/launch)
 - 2024 / 10 / 28-01: Permit Launch Week. [Teaser ↗︎](https://x.com/permit_io/status/1847213978352545944) [Go to launch page ↗︎](https://launchweek.permit.io)
 - 2024 / 10 / 21-25: Flipt Launch Week. [Teaser ↗︎](https://x.com/flipt_io/status/1846989763506852261)
 - 2024 / 10 / 21-25: Turso Launch Week #3. [Teaser ↗︎](https://x.com/tursodatabase/status/1844072254583574707) [Go to launch page ↗︎](https://turso.tech/launch-week)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds Langfuse launch week to list
