### PR TITLE
Added OpenInt to Launch Week 2024

### DIFF
--- a/lw/2024.mdx
+++ b/lw/2024.mdx
@@ -8,11 +8,14 @@ description: How Supabase, Langfuse, WorkOS and 41 more dev tools launched
   Total count: **60**
 </Tip>
 
-<Update label="/ 12" description="Count: 2">
+<Update label="/ 12" description="Count: 3">
   <Card title="Supabase Launch Week 13" href="https://x.com/kiwicopple/status/1856427550035325403">
     2024 / 12 / 02-06 // Preview on X ↗︎
   </Card>
   <Card title="Trigger.dev launchweek[0]" href="https://trigger.dev/launchweek/0">
+    2024 / 12 / 02-06 // Go to launch page ↗︎
+  </Card>
+  <Card title="OpenInt Premier Launchweek" href="https://openint.dev/launch-week">
     2024 / 12 / 02-06 // Go to launch page ↗︎
   </Card>
 </Update>


### PR DESCRIPTION
This adds OpenInt to the upcoming launch week: 
https://openint.dev/launch-week
