### PR TITLE
Add Magic Patterns Launch Week

### DIFF
--- a/lw/2024.mdx
+++ b/lw/2024.mdx
@@ -1,14 +1,14 @@
 ---
 title: Who launched in 2024
 sidebarTitle: 2024
-description: How Supabase, Langfuse, WorkOS and 54 more dev tools launched
+description: How Supabase, Langfuse, WorkOS and 55 more dev tools launched
 ---
 
 <Tip>
-  Total count: **85**
+  Total count: **86**
 </Tip>
 
-<Update label="/ 12" description="Count: 4">
+<Update label="/ 12" description="Count: 5">
   <Card title="Supabase Launch Week 13" href="https://x.com/kiwicopple/status/1856427550035325403">
     2024 / 12 / 02-06 // Preview on X ↗︎
   </Card>
@@ -20,6 +20,9 @@ description: How Supabase, Langfuse, WorkOS and 54 more dev tools launched
   </Card>
   <Card title="Quivr Launch Week">
     2024 / 12 / 02-06
+  </Card>
+  <Card title="Magic Patterns Launch Week 1" href="https://magicpatterns.com/launch-week">
+    2024 / 12 / 02-06 // Go to launch page ↗︎
   </Card>
 </Update>
 

--- a/lw/INDEX.mdx
+++ b/lw/INDEX.mdx
@@ -20,6 +20,9 @@ description: How Supabase, Resend, Raycast and more dev tools launched
   <Card title="Quivr Launch Week">
     2024 / 12 / 02-06
   </Card>
+  <Card title="Magic Patterns Launch Week 1" href="https://magicpatterns.com/launch-week">
+    2024 / 12 / 02-06 // Go to launch page ↗︎
+  </Card>
 </Update>
 
 <Update label="/ 11" description="Count: 14">


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add Magic Patterns Launch Week: https://www.magicpatterns.com/launch-week

## What is the new behavior?

Expected behavior is that docs still render:

<img width="1325" alt="CleanShot 2024-11-21 at 12 43 53@2x" src="https://github.com/user-attachments/assets/f6042c0b-6aeb-44ae-9b3f-3aaf337493b1">

## Additional context

Thanks for the tag on [X](https://x.com/fmerian/status/1858880096536494359)!  Excited to join the fun :confetti:

Any specific co-marketing planned?  Feel free to DM me if you have any specific things you want to collab on. 
