### PR TITLE
add Stack Auth Launch Week

### DIFF
--- a/HOME.mdx
+++ b/HOME.mdx
@@ -53,6 +53,9 @@ Participating companies:
   <Card title="OpenInt" href="https://openint.dev/" horizontal>
   </Card>
 
+  <Card title="Stack Auth" href="https://stack-auth.com/" horizontal>
+  </Card>
+
   <Card title="Quivr" href="https://quivr.com/" horizontal>
   </Card>
 
@@ -98,6 +101,9 @@ Participating companies:
   2024 / 12 / 02-06 // Go to launch page ↗︎
 </Card>
   <Card title="Upcoming: OpenInt Premier Launch Week" href="https://openint.dev/launch-week">
+    2024 / 12 / 02-06 // Go to launch page ↗︎
+  </Card>
+  <Card title="Upcoming: Stack Auth Launch Week" href="https://stack-auth.com/launch">
     2024 / 12 / 02-06 // Go to launch page ↗︎
   </Card>
   <Card title="Upcoming: Quivr Launch Week">

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Participating companies:
 - [Supabase](https://supabase.com)
 - [Trigger.dev](https://trigger.dev/)
 - [OpenInt](https://openint.dev/)
+- [Stack Auth](https://stack-auth.com/)
 - [Quivr](https://quivr.com/)
 - [Jamsocket](https://jamsocket.com/)
 - [Magic Patterns](https://magicpatterns.com/)

--- a/lw/2024.mdx
+++ b/lw/2024.mdx
@@ -19,6 +19,9 @@ description: How Supabase, Langfuse, WorkOS and 68 more dev tools launched
   <Card title="OpenInt Premier Launch Week" href="https://openint.dev/launch-week">
     2024 / 12 / 02-06 // Go to launch page ↗︎
   </Card>
+  <Card title="Stack Auth Launch Week" href="https://stack-auth.com/launch">
+    2024 / 12 / 02-06 // Go to launch page ↗︎
+  </Card>
   <Card title="Quivr Launch Week">
     2024 / 12 / 02-06
   </Card>

--- a/lw/INDEX.mdx
+++ b/lw/INDEX.mdx
@@ -20,6 +20,9 @@ description: How Supabase, Resend, Raycast and more dev tools launched
   <Card title="OpenInt Premier Launch Week" href="https://openint.dev/launch-week">
     2024 / 12 / 02-06 // Go to launch page ↗︎
   </Card>
+  <Card title="Stack Auth Launch Week" href="https://stack-auth.com/launch">
+    2024 / 12 / 02-06 // Go to launch page ↗︎
+  </Card>
   <Card title="Quivr Launch Week">
     2024 / 12 / 02-06
   </Card>


### PR DESCRIPTION
We have a launch week scheduled for Dec 2nd, during the Mega Launch Week.

See: https://stack-auth.com/launch