### PR TITLE
Add PropelAuth to launch week, Dec 2, 2024

### DIFF
--- a/HOME.mdx
+++ b/HOME.mdx
@@ -82,6 +82,9 @@ Participating companies:
   
   <Card title="Tempo Labs" href="https://tempolabs.ai/" horizontal>
   </Card>
+
+  <Card title="PropelAuth" href="https://www.propelauth.com/" horizontal>
+  </Card>
 </CardGroup>
 
 **Want to be part of it? [Create a Pull Request here](https://git.new/lw).**
@@ -142,6 +145,12 @@ Participating companies:
 <Card
   title="Upcoming: Tempo Labs Launch Week"
   href="https://tempolabs.ai/launch-week"
+>
+  2024 / 12 / 02-06 // Go to launch page ↗︎
+</Card>
+<Card
+  title="Upcoming: PropelAuth Launch Week"
+  href="https://www.propelauth.com/launch-week-0"
 >
   2024 / 12 / 02-06 // Go to launch page ↗︎
 </Card>

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Participating companies:
 - [Pinecone](https://www.pinecone.io/)
 - [Laminar](https://www.lmnr.ai/)
 - [Tempo Labs](https://tempolabs.ai/)
+- [PropelAuth](https://www.propelauth.com/)
 
 **Want to be part of it? [Create a Pull Request here](https://github.com/supabase-community/launchweek.dev/pulls).**
 

--- a/lw/2024.mdx
+++ b/lw/2024.mdx
@@ -52,6 +52,9 @@ description: How Supabase, Langfuse, WorkOS and 68 more dev tools launched
   <Card title="Tempo Labs Launch Week" href="https://tempolabs.ai/launch-week">
     2024 / 12 / 02-06 // Go to launch page ↗︎
   </Card>
+  <Card title="PropelAuth Launch Week" href="https://www.propelauth.com/launch-week-0">
+    2024 / 12 / 02-06 // Go to launch page ↗︎
+  </Card>
 </Update>
 
 <Update label="/ 11" description="Count: 16">

--- a/lw/INDEX.mdx
+++ b/lw/INDEX.mdx
@@ -53,6 +53,9 @@ description: How Supabase, Resend, Raycast and more dev tools launched
   <Card title="Tempo Labs Launch Week" href="https://tempolabs.ai/launch-week">
     2024 / 12 / 02-06 // Go to launch page ↗︎
   </Card>
+  <Card title="PropelAuth Launch Week" href="https://www.propelauth.com/launch-week-0">
+    2024 / 12 / 02-06 // Go to launch page ↗︎
+  </Card>
 </Update>
 
 <Update label="/ 11" description="Count: 16">


### PR DESCRIPTION
Updated HOME, launches, and readme. Let me know if I missed anything!