### PR TITLE
add laminar lw recap page

### DIFF
--- a/lw/INDEX.mdx
+++ b/lw/INDEX.mdx
@@ -26,8 +26,8 @@ description: How Supabase, Resend, Raycast and more dev tools launched
   <Card title="KeyHippo Launch Week 0" href="https://keyhippo.com/launch-week/0">
     2024 / 12 / 02-06 // Go to launch page ↗︎
   </Card>
-  <Card title="Laminar Launch Week">
-    2024 / 12 / 02-06
+  <Card title="Laminar Launch Week" href="https://www.lmnr.ai/blog/2024-12-01-launch-week-1">
+    2024 / 12 / 02-06 // Read the recap ↗︎
   </Card>
   <Card title="Magic Patterns Launch Week 1" href="https://magicpatterns.com/launch-week">
     2024 / 12 / 02-06 // Go to launch page ↗︎


### PR DESCRIPTION
## What kind of change does this PR introduce?

Update Laminar launch week recap

## What is the current behavior?

No link to launch week.

## What is the new behavior?

Link to the recap blog post

## Additional context

Add any other context or screenshots.
