### PR TITLE
Add Ragie Launch Week

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 
 2025 / 01 / W03
 
+- 13-15: Ragie Launch Week - Fully managed RAG-as-a-Service // [Preview on X ↗︎](https://x.com/ragieai/status/1877445370105520349)
 - 13-17: Appsmith Advance Winter 2025 Launch Week - Open-source low-code apps platform // [Go to launch page ↗︎](https://www.appsmith.com/event/appsmith-advance-winter-2025-launch) 
 
 **Want to be part of it? [Create a Pull Request here](https://github.com/supabase-community/launchweek.dev/pulls).**

--- a/home.mdx
+++ b/home.mdx
@@ -34,6 +34,9 @@ What's a launch week? It's a week of announcing new features. [See examples here
 <Card title="Appsmith Advance Winter 2025 Launch Week" href="https://www.appsmith.com/event/appsmith-advance-winter-2025-launch">
   Open-source low-code apps platform // Go to launch page ↗︎
 </Card>
+<Card title="Ragie Launch Week" href="https://x.com/ragieai/status/1877445370105520349">
+  Fully managed RAG-as-a-Service // Preview on X ↗︎
+</Card>
 
 ## objectives
 

--- a/lw/2025.mdx
+++ b/lw/2025.mdx
@@ -30,6 +30,9 @@ Awesome! Add it to the list by [creating an issue](https://git.new/lw/issues) or
 <Card title="Appsmith Advance Winter 2025 Launch Week" href="https://www.appsmith.com/event/appsmith-advance-winter-2025-launch">
   Open-source low-code apps platform
 </Card>
+<Card title="Ragie Launch Week" href="https://x.com/ragieai/status/1877445370105520349">
+  Fully managed RAG-as-a-Service
+</Card>
 
 ## more
 
@@ -45,6 +48,7 @@ Browse launch weeks by year.
   </Card>
   <Card title="2021 ->" href="2021" horizontal>
   </Card>
+  
 </CardGroup>
 
 ---


### PR DESCRIPTION
Ragie provides secure retrieval augmented generation APIs. Launch week on January 13-15, 2025.

[Preview on 𝕏](https://x.com/ragieai/status/1877445370105520349)