### PR TITLE
Add Bugster Launch Week

### DIFF
--- a/lw/2025.mdx
+++ b/lw/2025.mdx
@@ -6,12 +6,16 @@ description: How Pinecone, Resend, Supabase and 73 more developer tools launched
 ---
 
 <Info>
-  Total count: **91**
+  Total count: **92**
 </Info>
 
-<Update label="09" description="Count: 1">
+<Update label="09" description="Count: 2">
 
 2025 / 09 / W36
+
+<Card title="Bugster Launch Week" href="https://www.bugster.dev/">
+  The AI QA Engineer
+</Card>
 
 <Card title="SigNoz Launch Week 5.0" href="https://signoz.io/launch-week/">
   OpenTelemetry native, open-source observability platform

--- a/lw/2025.mdx
+++ b/lw/2025.mdx
@@ -1,7 +1,7 @@
 ---
 title: Who is launching in 2025
 sidebarTitle: 2025
-description: How Pinecone, Resend, Supabase and 73 more developer tools launched
+description: How Pinecone, Resend, Supabase and 74 more developer tools launched
 "og:description": "Discover which developer-first companies ran a launch week in 2025"
 ---
 
@@ -13,8 +13,8 @@ description: How Pinecone, Resend, Supabase and 73 more developer tools launched
 
 2025 / 09 / W36
 
-<Card title="Bugster Launch Week" href="https://www.bugster.dev/">
-  The AI QA Engineer
+<Card title="Bugster Launch Week">
+  AI-powered E2E testing platform
 </Card>
 
 <Card title="SigNoz Launch Week 5.0" href="https://signoz.io/launch-week/">


### PR DESCRIPTION
Adds Bugster Launch Week to 2025 / 09 / W36.

- Title: “Bugster Launch Week”
- Link: https://www.bugster.dev/
- Tagline: The AI QA Engineer
- Updated September count: 1 → 2
- Updated total count: 91 → 92