### PR TITLE
Add Docsalot Launch Week

### DIFF
--- a/lw/2025.mdx
+++ b/lw/2025.mdx
@@ -13,7 +13,7 @@ description: How Pinecone, Resend, Supabase and 75 more developer tools launched
 
 2025 / 09 / W37
 
-<Card title="Docsalot Launch Week" href="https://docsalot.com/">
+<Card title="Docsalot Launch Week" href="https://docsalot.dev/launch-week">
   Create and Maintain Docs with AI
 </Card>
 

--- a/lw/2025.mdx
+++ b/lw/2025.mdx
@@ -6,10 +6,16 @@ description: How Pinecone, Resend, Supabase and 75 more developer tools launched
 ---
 
 <Info>
-  Total count: **93**
+  Total count: **94**
 </Info>
 
-<Update label="09" description="Count: 3">
+<Update label="09" description="Count: 4">
+
+2025 / 09 / W37
+
+<Card title="Docsalot Launch Week" href="https://docsalot.com/">
+  Create and Maintain Docs with AI
+</Card>
 
 2025 / 09 / W36
 


### PR DESCRIPTION
Adds https://docsalot.dev Launch Week.

- Updated the overall total count
- Updates the Month counter
- Created a new week header
- Adds the docsalot card.