### PR TITLE
Add link to cubic launch week

### DIFF
--- a/home.mdx
+++ b/home.mdx
@@ -34,7 +34,7 @@ What's a launch week? It's a week of announcing new features. [See examples here
   AI-powered E2E testing platform
 </Card>
 
-<Card title="cubic launch week">
+<Card title="cubic launch week" href="https://www.cubic.dev/blog/launch-week-1">
   AI code reviews
 </Card>
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

cubic does not have a link

## What is the new behavior?

add href link for cubic launch week post