### PR TITLE
Add Diploi Launch Week

### DIFF
--- a/lw/2025.mdx
+++ b/lw/2025.mdx
@@ -14,7 +14,7 @@ description: How Supabase, Daytona, Resend, and 81 more developer tools launched
 2025 / 09 / W39
 
 <Card title="Diploi Launch Week 1" href="https://diploi.com/launchweek">
-  Zero-install remote development and one-click production deployment. Support for any stack, including Lovable apps.
+  Zero-install remote development, one-click production deployment
 </Card>
 
 <Card title="Turbot Launch Week 10" href="https://turbot.com/launch-week/10">


### PR DESCRIPTION
# Changes
Adds https://diploi.com/ Launch Week

- Updated description count for 2025
- Updates total count
- Adds the Diploi card