### PR TITLE
Add Daydream Scope Launch Week

### DIFF
--- a/lw/2026.mdx
+++ b/lw/2026.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Who is launching in 2026"
 sidebarTitle: "2026"
-description: "How cubic, Surfpool, Tinybird and 7 more developer tools launched in 2026"
+description: "How cubic, Surfpool, Tinybird and 8 more developer tools launched in 2026"
 "og:description": "Discover which developer-first companies ran a launch week in 2026"
 ---
 
@@ -14,7 +14,7 @@ description: "How cubic, Surfpool, Tinybird and 7 more developer tools launched 
 2026 / 03 / W14
 
 <Card title="Daydream Scope Launch Week 1" href="https://daydream.live/launch-week-01">
-  Real-time AI video integrations for creative tools. Spout, Syphon, NDI, OSC, MIDI, and DMX for VJs, creative technologists, and installation artists.
+  Real-time AI video integrations for creative tools
 </Card>
 
 <Card title="Diploi Launch Week 2" href="https://diploi.com/launchweek">

--- a/lw/2026.mdx
+++ b/lw/2026.mdx
@@ -6,12 +6,16 @@ description: "How cubic, Surfpool, Tinybird and 7 more developer tools launched 
 ---
 
 <Info>
-  Total count: **10**
+  Total count: **11**
 </Info>
 
-<Update label="03" description="Count: 5">
+<Update label="03" description="Count: 6">
 
 2026 / 03 / W14
+
+<Card title="Daydream Scope Launch Week 1" href="https://daydream.live/launch-week-01">
+  Real-time AI video integrations for creative tools. Spout, Syphon, NDI, OSC, MIDI, and DMX for VJs, creative technologists, and installation artists.
+</Card>
 
 <Card title="Diploi Launch Week 2" href="https://diploi.com/launchweek">
   Host web apps in seconds and code with remote dev environments


### PR DESCRIPTION
Adds Daydream Scope Launch Week 1 to 2026 / 03 / W14.

Daydream Scope is an open-source, local-first application for real-time AI video transformation. This launch week covers five integrations (Spout, Syphon, NDI, OSC, MIDI, DMX) that connect Scope to creative tools used by VJs, creative technologists, and installation artists.

Launch week page: https://daydream.live/launch-week-01