### PR TITLE
Add Resend Launch Week 6

### DIFF
--- a/lw/2026.mdx
+++ b/lw/2026.mdx
@@ -1,13 +1,23 @@
 ---
 title: "Who is launching in 2026"
 sidebarTitle: "2026"
-description: "How cubic, Surfpool, Tinybird and 8 more developer tools launched in 2026"
+description: "How cubic, Surfpool, Tinybird and 9 more developer tools launched in 2026"
 "og:description": "Discover which developer-first companies ran a launch week in 2026"
 ---
 
 <Info>
-  Total count: **11**
+  Total count: **12**
 </Info>
+
+<Update label="04" description="Count: 1">
+
+2026 / 04 / W16
+
+<Card title="Resend Launch Week 6" href="https://resend.com/launch-weeks/6">
+  Email API
+</Card>
+
+</Update>
 
 <Update label="03" description="Count: 6">
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Time for Resend's [6th Launch Week](https://resend.com/launch-weeks/6), happening on April 13th to 17th, Week 16.

