### PR TITLE
Add Steel.dev Launch Week 3

### DIFF
--- a/lw/2026.mdx
+++ b/lw/2026.mdx
@@ -6,10 +6,16 @@ description: "How Kilo Code, Resend, Surfpool and 14 more developer tools launch
 ---
 
 <Info>
-  Total count: **18**
+  Total count: **19**
 </Info>
 
-<Update label="06" description="Count: 2">
+<Update label="06" description="Count: 3">
+
+2026 / 06 / W26
+
+<Card title="Steel.dev Launch Week 3" href="https://steel.dev/launch-week">
+  Browser infrastructure for AI agents
+</Card>
 
 2026 / 06 / W24
 

--- a/lw/2026.mdx
+++ b/lw/2026.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Who is launching in 2026"
 sidebarTitle: "2026"
-description: "How Kilo Code, Resend, Surfpool and 14 more developer tools launched in 2026"
+description: "How Kilo Code, Resend, Surfpool and 15 more developer tools launched in 2026"
 "og:description": "Discover which developer-first companies ran a launch week in 2026"
 ---
 


### PR DESCRIPTION
Add Steel.dev Launch Week 3 for June 22–26, 2026 (W26) to the 2026 launch weeks listing.

Thx @fmerian 🚀